### PR TITLE
Append/prepend updates

### DIFF
--- a/internal/gotodo/todomanager.go
+++ b/internal/gotodo/todomanager.go
@@ -66,27 +66,9 @@ func (me *TodoManager) Add(todoStr string) (int, error) {
 	return todo.TodoID, me.Storage.Create(todo)
 }
 
-// Update takes the ID number of an existing Todo and a parseable todo string and merges
-// contents of the existing todo and the update.
-func (me *TodoManager) Update(todoID int, todoStr string) error {
-	todo, err := me.Storage.Get(todoID)
-	if err != nil {
-		return err
-	}
-
-	newTodo := FromString(todoStr)
-
-	todo.Priority = newTodo.Priority
-	todo.Description = newTodo.Description
-	todo.Projects = newTodo.Projects
-	todo.Contexts = newTodo.Contexts
-
-	return me.Storage.Update(todoID, todo)
-}
-
-// Replace takes the ID number of an existing Todo and a parseable todo string and replaces all
+// Update takes the ID number of an existing Todo and a parseable todo string and replaces all
 // contents of the existing todo with the update.
-func (me *TodoManager) Replace(todoID int, todoStr string) error {
+func (me *TodoManager) Update(todoID int, todoStr string) error {
 	todo, err := me.Storage.Get(todoID)
 	if err != nil {
 		return err
@@ -102,6 +84,30 @@ func (me *TodoManager) Replace(todoID int, todoStr string) error {
 	todo.Projects = newTodo.Projects
 	todo.Contexts = newTodo.Contexts
 	todo.CustomAttributes = newTodo.CustomAttributes
+
+	return me.Storage.Update(todoID, todo)
+}
+
+// Prepend adds a string message to the front of a todo description
+func (me *TodoManager) Prepend(todoID int, prependStr string) error {
+	todo, err := me.Storage.Get(todoID)
+	if err != nil {
+		return err
+	}
+
+	todo.Description = prependStr + " " + todo.Description
+
+	return me.Storage.Update(todoID, todo)
+}
+
+// Append adds a string message to the end of a todo description
+func (me *TodoManager) Append(todoID int, appendStr string) error {
+	todo, err := me.Storage.Get(todoID)
+	if err != nil {
+		return err
+	}
+
+	todo.Description = todo.Description + " " + appendStr
 
 	return me.Storage.Update(todoID, todo)
 }

--- a/internal/gotodo/todomanager_test.go
+++ b/internal/gotodo/todomanager_test.go
@@ -182,41 +182,40 @@ func TestUpdate(t *testing.T) {
 
 	todo, err = todoManager.Storage.Get(0)
 	assert.NoError(t, err)
-	assert.Equal(t, "Mock TodoManager struct +gotodo @testing", todo.Description)
-	assert.Equal(t, ValidTime(ts), todo.CreationDate)
-	assert.Equal(t, 1, todo.Priority)
-}
-
-func TestReplace(t *testing.T) {
-	todoManager := getTestTodoManager()
-	todoStr := "(A) 2020-05-01 Mock TodoManager struct +gotodo @testing"
-	ts, err := time.Parse(TimeFormat, "2020-04-28")
-	assert.NoError(t, err)
-
-	items, err := todoManager.Storage.List()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(items))
-
-	todo, err := todoManager.Storage.Get(0)
-	assert.NoError(t, err)
-	assert.Equal(t, "Work on unit tests @codehealth +gotodo", todo.Description)
-	assert.Equal(t, ValidTime(ts), todo.CreationDate)
-	assert.Equal(t, 2, todo.Priority)
-
-	todoManager.Replace(0, todoStr)
-
-	items, err = todoManager.Storage.List()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(items))
-
-	todo, err = todoManager.Storage.Get(0)
-	assert.NoError(t, err)
 
 	assert.Equal(t, "Mock TodoManager struct +gotodo @testing", todo.Description)
 	ts2, err := time.Parse(TimeFormat, "2020-05-01")
 	assert.NoError(t, err)
 	assert.Equal(t, ValidTime(ts2), todo.CreationDate)
 	assert.Equal(t, 1, todo.Priority)
+}
+
+func TestPrepend(t *testing.T) {
+	todoManager := getTestTodoManager()
+
+	todo, err := todoManager.Storage.Get(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "Work on unit tests @codehealth +gotodo", todo.Description)
+
+	todoManager.Prepend(0, "prepend string")
+
+	todo, err = todoManager.Storage.Get(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "prepend string Work on unit tests @codehealth +gotodo", todo.Description)
+}
+
+func TestAppend(t *testing.T) {
+	todoManager := getTestTodoManager()
+
+	todo, err := todoManager.Storage.Get(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "Work on unit tests @codehealth +gotodo", todo.Description)
+
+	todoManager.Append(0, "append string")
+
+	todo, err = todoManager.Storage.Get(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "Work on unit tests @codehealth +gotodo append string", todo.Description)
 }
 
 func TestPrioritize(t *testing.T) {


### PR DESCRIPTION
### Summary

This PR modifies the update behavior to support append/prepend/replace instead of the previous put and patch updates. Patch updates were the previous default behavior but weren't subject to the same parsing scrutiny as other inputs. We've dropped that paradigm, now supporting replace with full parsing, and description prepend/append.

### Related Issues

None

### Verification Steps

1. Create a todo
2. Edit the todo with the append flag. Note updated content added to the end of the description.
3. Edit the todo with the prepend flag. Note updated content added to the beginning of the description.
4. Edit the todo with no flags. Note the whole todo was replaced by modified content.
